### PR TITLE
Optional "original" folder

### DIFF
--- a/OpenKh.Egs/Helpers.cs
+++ b/OpenKh.Egs/Helpers.cs
@@ -15,6 +15,7 @@ namespace OpenKh.Egs
 
         public static IEnumerable<string> GetAllFiles(string folder)
         {
+            if(!Directory.Exists(folder)) return Enumerable.Empty<string>();
             return Directory.EnumerateFiles(folder, "*.*", SearchOption.AllDirectories)
                             .Select(x => x.Replace($"{folder}\\", "")
                             .Replace(@"\", "/"));


### PR DESCRIPTION
Make the "original" folder non-mandatory for patches that only modify "remastered" assets and prevent any errors when the original folder does not exist.